### PR TITLE
feature/save-and-load

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,14 @@
                 <span class="btn-icon">🗑️</span>
                 Limpar Batalha
               </button>
+              <button id="save-battle-btn" class="btn btn-outline">
+                <span class="btn-icon">💾</span>
+                Salvar Batalha
+              </button>
+              <button id="load-battle-btn" class="btn btn-outline">
+                <span class="btn-icon">📂</span>
+                Carregar Batalha
+              </button>
             </div>
             <div class="battle-info">
               <div class="info-card">

--- a/index.html
+++ b/index.html
@@ -37,15 +37,15 @@
               </button>
               <button id="clear-battle-btn" class="btn btn-outline">
                 <span class="btn-icon">🗑️</span>
-                Limpar Batalha
+                Limpar
               </button>
               <button id="save-battle-btn" class="btn btn-outline">
                 <span class="btn-icon">💾</span>
-                Salvar Batalha
+                Salvar
               </button>
               <button id="load-battle-btn" class="btn btn-outline">
                 <span class="btn-icon">📂</span>
-                Carregar Batalha
+                Carregar
               </button>
             </div>
             <div class="battle-info">

--- a/js/models/Creature.js
+++ b/js/models/Creature.js
@@ -127,4 +127,19 @@ export class Creature {
     this.updateElement(this.element);
     this.bindEvents(); // Re-vincula os eventos após a sobreescrita do innerHTML
   }
+
+  /**
+   * Retorna uma representação JSON do objeto.
+   * @returns {object} Um objeto simples com os dados da criatura.
+   */
+  toJSON() {
+    return {
+      id: this.id,
+      name: this.name,
+      hp: this.hp,
+      ac: this.ac,
+      currentHp: this.currentHp,
+      type: this.type,
+    };
+  }
 }

--- a/js/services/BattleManager.js
+++ b/js/services/BattleManager.js
@@ -122,4 +122,38 @@ export class BattleManager extends EventTarget {
     });
     this.dispatchEvent(event);
   }
+
+  /**
+   * Retorna o estado atual da batalha para salvar.
+   * @returns {object} O estado da batalha.
+   */
+  getStateForSave() {
+    return {
+      players: this.players.map((p) => p.toJSON()),
+      enemies: this.enemies.map((e) => e.toJSON()),
+    };
+  }
+
+  /**
+   * Carrega o estado da batalha a partir de um objeto.
+   * @param {object} state - O estado da batalha a ser carregado.
+   */
+  loadState(state) {
+    if (!state || !state.players || !state.enemies) {
+      console.error("Estado inválido:", state);
+      return;
+    }
+
+    this.players = [];
+    this.enemies = [];
+
+    state.players.forEach((playerData) => {
+      this.addCreature(playerData, "player");
+    });
+    state.enemies.forEach((enemyData) => {
+      this.addCreature(enemyData, "enemy");
+    });
+
+    this.dispatchStateChange();
+  }
 }

--- a/js/services/UIManager.js
+++ b/js/services/UIManager.js
@@ -20,6 +20,49 @@ export class UIManager {
   }
 
   /**
+   * Lida com o clique no botão de salvar a batalha.
+   */
+  handleSaveBattle() {
+    const state = this.battleManager.getStateForSave();
+    const dataStr =
+      "data:text/json;charset=utf-8," +
+      encodeURIComponent(JSON.stringify(state, null, 2));
+    const downloadAnchorNode = document.createElement("a");
+    downloadAnchorNode.setAttribute("href", dataStr);
+    downloadAnchorNode.setAttribute("download", "battle.json");
+    document.body.appendChild(downloadAnchorNode); // required for firefox
+    downloadAnchorNode.click();
+    downloadAnchorNode.remove();
+  }
+
+  /**
+   * Lida com o clique no botão de carregar a batalha.
+   */
+  handleLoadBattle() {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json";
+    input.onchange = (e) => {
+      const file = e.target.files[0];
+      if (!file) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        try {
+          const state = JSON.parse(event.target.result);
+          this.battleManager.loadState(state);
+        } catch (error) {
+          alert("Erro ao carregar o arquivo de batalha.");
+          console.error("Erro ao analisar o JSON:", error);
+        }
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  }
+
+  /**
    * Vincula todos os ouvintes de eventos gerais da UI.
    */
   bindEvents() {
@@ -49,6 +92,12 @@ export class UIManager {
     document
       .getElementById("clear-battle-btn")
       .addEventListener("click", () => this.handleClearBattle());
+    document
+      .getElementById("save-battle-btn")
+      .addEventListener("click", () => this.handleSaveBattle());
+    document
+      .getElementById("load-battle-btn")
+      .addEventListener("click", () => this.handleLoadBattle());
 
     // Ouve as mudanças de estado do BattleManager
     this.battleManager.addEventListener("state-change", (e) =>

--- a/js/services/UIManager.js
+++ b/js/services/UIManager.js
@@ -20,49 +20,6 @@ export class UIManager {
   }
 
   /**
-   * Lida com o clique no botão de salvar a batalha.
-   */
-  handleSaveBattle() {
-    const state = this.battleManager.getStateForSave();
-    const dataStr =
-      "data:text/json;charset=utf-8," +
-      encodeURIComponent(JSON.stringify(state, null, 2));
-    const downloadAnchorNode = document.createElement("a");
-    downloadAnchorNode.setAttribute("href", dataStr);
-    downloadAnchorNode.setAttribute("download", "battle.json");
-    document.body.appendChild(downloadAnchorNode); // required for firefox
-    downloadAnchorNode.click();
-    downloadAnchorNode.remove();
-  }
-
-  /**
-   * Lida com o clique no botão de carregar a batalha.
-   */
-  handleLoadBattle() {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = ".json";
-    input.onchange = (e) => {
-      const file = e.target.files[0];
-      if (!file) {
-        return;
-      }
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        try {
-          const state = JSON.parse(event.target.result);
-          this.battleManager.loadState(state);
-        } catch (error) {
-          alert("Erro ao carregar o arquivo de batalha.");
-          console.error("Erro ao analisar o JSON:", error);
-        }
-      };
-      reader.readAsText(file);
-    };
-    input.click();
-  }
-
-  /**
    * Vincula todos os ouvintes de eventos gerais da UI.
    */
   bindEvents() {
@@ -184,6 +141,55 @@ export class UIManager {
   }
 
   /**
+   * Lida com o clique no botão de salvar a batalha.
+   */
+  handleSaveBattle() {
+    const state = this.battleManager.getStateForSave();
+    const dataStr =
+      "data:text/json;charset=utf-8," +
+      encodeURIComponent(JSON.stringify(state, null, 2));
+    const downloadAnchorNode = document.createElement("a");
+    downloadAnchorNode.setAttribute("href", dataStr);
+    downloadAnchorNode.setAttribute("download", "battle.json");
+    document.body.appendChild(downloadAnchorNode); // required for firefox
+    downloadAnchorNode.click();
+    downloadAnchorNode.remove();
+  }
+
+  /**
+   * Lida com o clique no botão de carregar a batalha.
+   */
+  handleLoadBattle() {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json";
+    input.onchange = (e) => {
+      const file = e.target.files[0];
+      if (!file) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        try {
+          const state = JSON.parse(event.target.result);
+          if (
+            confirm(
+              "Tem certeza que deseja carregar uma nova batalha? Esta ação não pode ser desfeita."
+            )
+          ) {
+            this.battleManager.loadState(state);
+          }
+        } catch (error) {
+          alert("Erro ao carregar o arquivo de batalha.");
+          console.error("Erro ao analisar o JSON:", error);
+        }
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  }
+
+  /**
    * Atualiza toda a UI com base no novo estado.
    * @param {object} state - O novo estado da batalha.
    */
@@ -205,9 +211,7 @@ export class UIManager {
     if (creatures.length === 0) {
       container.innerHTML = `
         <div class="empty-state">
-          <p>Nenhum ${
-            type === "player" ? "jogador" : "inimigo"
-          } adicionado</p>
+          <p>Nenhum ${type === "player" ? "jogador" : "inimigo"} adicionado</p>
           <small>Use o painél ${
             type === "player" ? "abaixo" : "acima"
           } para adicionar</small>


### PR DESCRIPTION
# Salvar e Carregar cartões de criatura com arquivo JSON
Este PR adiciona dois botões no painel de controle, um para salvar os cartões que estão sendo utilizados na batalha, em formato .json, enquanto o outro dispõe as informações de qualquer save que você tenha feito.